### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The site code.angularjs.org is *not* a CDN. The angular builds there are to be
 used during the development of angularjs. The site is not suitable for
 production usage.
 
-If you are looking for a CDN link to angularjs visit [anuglarjs.org](https://www.angularjs.org/).
+If you are looking for a CDN link to angularjs visit [angularjs.org](https://www.angularjs.org/).


### PR DESCRIPTION
There is a typo at a link's name in the last line of README which is anuglarjs.org. 
I fix it to angularjs.org.
